### PR TITLE
fix: Set default empty string value for eks oidc var

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This module is provide a bucket for the needs of UDS. While the original intent 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.6.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.7.0 |
 
 ## Modules
 
@@ -46,7 +46,7 @@ This module is provide a bucket for the needs of UDS. While the original intent 
 | <a name="input_access_logging_enabled"></a> [access\_logging\_enabled](#input\_access\_logging\_enabled) | If true, set up access logging of the S3 bucket to a different S3 bucket, provided by the variables `logging_bucket_id` and `logging_bucket_path`. Caution: Enabling this will likely cause LOTS of access logs, as one is generated each time the bucket is accessed and Loki will be hitting the bucket a lot! | `bool` | `false` | no |
 | <a name="input_create_bucket_lifecycle"></a> [create\_bucket\_lifecycle](#input\_create\_bucket\_lifecycle) | If true, create a bucket lifecycle | `bool` | `false` | no |
 | <a name="input_create_irsa"></a> [create\_irsa](#input\_create\_irsa) | If true, create the IAM role and policy to be used in IRSA | `bool` | `true` | no |
-| <a name="input_eks_oidc_provider_arn"></a> [eks\_oidc\_provider\_arn](#input\_eks\_oidc\_provider\_arn) | EKS OIDC Provider ARN e.g., arn:aws:iam::<ACCOUNT-ID>:oidc-provider/<var.eks\_oidc\_provider> | `string` | n/a | yes |
+| <a name="input_eks_oidc_provider_arn"></a> [eks\_oidc\_provider\_arn](#input\_eks\_oidc\_provider\_arn) | EKS OIDC Provider ARN e.g., arn:aws:iam::<ACCOUNT-ID>:oidc-provider/<var.eks\_oidc\_provider> | `string` | `""` | no |
 | <a name="input_expiration_days"></a> [expiration\_days](#input\_expiration\_days) | Requires create\_bucket\_lifecycle; number of days before bucket data expires | `number` | `365` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | If true, destroys all objects in the bucket when the bucket is destroyed so that the bucket can be destroyed without error. Objects that are destroyed in this way are NOT recoverable. | `bool` | `false` | no |
 | <a name="input_irsa_iam_permissions_boundary_arn"></a> [irsa\_iam\_permissions\_boundary\_arn](#input\_irsa\_iam\_permissions\_boundary\_arn) | IAM permissions boundary ARN for IRSA roles | `string` | `""` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,7 @@ variable "irsa_iam_permissions_boundary_arn" {
 variable "eks_oidc_provider_arn" {
   description = "EKS OIDC Provider ARN e.g., arn:aws:iam::<ACCOUNT-ID>:oidc-provider/<var.eks_oidc_provider>"
   type        = string
+  default     = ""
 }
 
 variable "tags" {


### PR DESCRIPTION
As part of the ongoing effort to decouple the S3 and IRSA modules, making the `eks_oidc_provider_arn` variable optional by setting a default empty string value.

Relates to https://github.com/defenseunicorns/uds-package-dubbd/issues/337 & https://github.com/defenseunicorns/uds-package-dubbd/pull/384

Once this PR is merged, a `v0.0.4` release will be created, and can then be referenced/updated in the DUBBD-AWS loki terraform, which will allow us to remove [this variable](https://github.com/defenseunicorns/uds-package-dubbd/blob/6ef423085bf506de9008d92136009e9101b4e0e1/aws/loki/main.tf#L49).