### PR TITLE
fix: Allow s3 bucket policy to be created when create_irsa is false

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
-          aws-region: us-east-1
+          aws-region: us-west-2
           # 21600 seconds == 6 hours
           # 1800 seconds == 30 minutes
           role-duration-seconds: 1800

--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ This module is provide a bucket for the needs of UDS. While the original intent 
 |------|-------------|
 | <a name="output_irsa_role"></a> [irsa\_role](#output\_irsa\_role) | ARN of the IRSA Role |
 | <a name="output_s3_bucket"></a> [s3\_bucket](#output\_s3\_bucket) | S3 Bucket Name |
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This module is provide a bucket for the needs of UDS. While the original intent 
 | [aws_iam_role_policy_attachment.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_bucket_logging.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.bucket_policy_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_versioning.versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_iam_policy_document.irsa_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
@@ -57,6 +58,7 @@ This module is provide a bucket for the needs of UDS. While the original intent 
 | <a name="input_kubernetes_service_account"></a> [kubernetes\_service\_account](#input\_kubernetes\_service\_account) | Kubernetes service account for IRSA | `string` | `"default"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for all resources that use a randomized suffix | `string` | n/a | yes |
 | <a name="input_policy_name_suffix"></a> [policy\_name\_suffix](#input\_policy\_name\_suffix) | IAM Policy name suffix | `string` | `"irsa-policy"` | no |
+| <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | ARN of the IAM role to be used in the S3 bucket policy | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_transition_days"></a> [transition\_days](#input\_transition\_days) | Requires create\_bucket\_lifecycle; number of days before transitioning to cold storage | `number` | `30` | no |
 
@@ -66,4 +68,3 @@ This module is provide a bucket for the needs of UDS. While the original intent 
 |------|-------------|
 | <a name="output_irsa_role"></a> [irsa\_role](#output\_irsa\_role) | ARN of the IRSA Role |
 | <a name="output_s3_bucket"></a> [s3\_bucket](#output\_s3\_bucket) | S3 Bucket Name |
-<!-- END_TF_DOCS -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,4 +1,4 @@
-# Examples Complete
+<!-- END_TF_DOCS --># Examples Complete
 
 Example of how to use this S3 module. 
 
@@ -12,18 +12,24 @@ Example of how to use this S3 module.
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.62.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_bucket"></a> [bucket](#module\_bucket) | ../../ | n/a |
+| <a name="module_irsa"></a> [irsa](#module\_irsa) | github.com/defenseunicorns/terraform-aws-uds-irsa | v0.0.1 |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | terraform-aws-modules/kms/aws | 1.5.0 |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_iam_policy.loki_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 
@@ -36,7 +42,6 @@ No resources.
 | <a name="input_irsa_iam_permissions_boundary_arn"></a> [irsa\_iam\_permissions\_boundary\_arn](#input\_irsa\_iam\_permissions\_boundary\_arn) | IAM permissions boundary ARN. | `string` | `""` | no |
 | <a name="input_irsa_iam_role_name"></a> [irsa\_iam\_role\_name](#input\_irsa\_iam\_role\_name) | IRSA role name. | `string` | `"ex-complete-irsa-role"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix to use when naming resources. | `string` | `"ex-complete"` | no |
-| <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy into | `string` | `"us-east-2"` | no |
 
 ## Outputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -28,7 +28,7 @@ Example of how to use this S3 module.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.loki_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.test_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
@@ -42,6 +42,7 @@ Example of how to use this S3 module.
 | <a name="input_irsa_iam_permissions_boundary_arn"></a> [irsa\_iam\_permissions\_boundary\_arn](#input\_irsa\_iam\_permissions\_boundary\_arn) | IAM permissions boundary ARN. | `string` | `""` | no |
 | <a name="input_irsa_iam_role_name"></a> [irsa\_iam\_role\_name](#input\_irsa\_iam\_role\_name) | IRSA role name. | `string` | `"ex-complete-irsa-role"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix to use when naming resources. | `string` | `"ex-complete"` | no |
+| <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | ARN of the IAM role to be used in the S3 bucket policy | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,6 +1,6 @@
-<!-- END_TF_DOCS --># Examples Complete
+# Examples Complete
 
-Example of how to use this S3 module. 
+Example of how to use this S3 module.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/examples/complete/example_complete.tfvars
+++ b/examples/complete/example_complete.tfvars
@@ -1,6 +1,7 @@
 name_prefix                       = "ex-complete"
 irsa_iam_role_name                = "ex-complete-irsa-role"
 irsa_iam_permissions_boundary_arn = null
-eks_oidc_provider_arn             = null
+eks_oidc_provider_arn             = "arn:aws:iam::111111111111:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/22222222222222222222222222222222"
 kms_key_arn                       = null
 force_destroy                     = true
+create_bucket_lifecycle           = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -9,7 +9,7 @@ module "bucket" {
 
   name_prefix                       = var.name_prefix
   create_irsa                       = var.create_irsa
-  role_arn                          = var.create_irsa ? 0 : module.irsa[0].role_arn
+  role_arn                          = length(module.irsa) > 0 ? module.irsa[0].role_arn : var.role_arn
   irsa_iam_role_name                = var.irsa_iam_role_name
   irsa_iam_permissions_boundary_arn = var.irsa_iam_permissions_boundary_arn
   eks_oidc_provider_arn             = var.eks_oidc_provider_arn
@@ -26,18 +26,19 @@ module "kms_key" {
 # The S3 bucket policy needs a real IAM role ARN to create successfully, so when create_irsa is set to false
 # we need to create the IRSA resources via the IRSA module.
 module "irsa" {
-  count                         = var.create_irsa ? 0 : 1 // Only create when create_irsa = false
   source                        = "github.com/defenseunicorns/terraform-aws-uds-irsa?ref=v0.0.1"
+  count                         = var.create_irsa ? 0 : 1 // Only create when create_irsa = false
   name                          = "create_irsa_false_role"
   provider_url                  = "oidc.eks.us-west-2.amazonaws.com/id/dummy-oidc-provider"
   oidc_fully_qualified_subjects = ["system:serviceaccount:logging:logging-loki"]
-  policy_arns                   = [aws_iam_policy.loki_policy.arn]
+  policy_arns                   = [aws_iam_policy.test_policy[0].arn]
 }
 
-resource "aws_iam_policy" "loki_policy" {
+resource "aws_iam_policy" "test_policy" {
+  count       = var.create_irsa ? 0 : 1
   name        = var.name_prefix
   path        = "/"
-  description = "IAM policy for Loki to have necessary permissions to use S3 for storing logs."
+  description = "IAM policy for testing S3 bucket policy creation."
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,11 +2,14 @@ output "bucket_id" {
   value = module.bucket.s3_bucket
 }
 
+data "aws_partition" "current" {}
+
 module "bucket" {
   source = "../../"
 
   name_prefix                       = var.name_prefix
   create_irsa                       = var.create_irsa
+  role_arn                          = var.create_irsa ? 0 : module.irsa[0].role_arn
   irsa_iam_role_name                = var.irsa_iam_role_name
   irsa_iam_permissions_boundary_arn = var.irsa_iam_permissions_boundary_arn
   eks_oidc_provider_arn             = var.eks_oidc_provider_arn
@@ -18,4 +21,44 @@ module "bucket" {
 module "kms_key" {
   source  = "terraform-aws-modules/kms/aws"
   version = "1.5.0"
+}
+
+# The S3 bucket policy needs a real IAM role ARN to create successfully, so when create_irsa is set to false
+# we need to create the IRSA resources via the IRSA module.
+module "irsa" {
+  count                         = var.create_irsa ? 0 : 1 // Only create when create_irsa = false
+  source                        = "github.com/defenseunicorns/terraform-aws-uds-irsa?ref=v0.0.1"
+  name                          = "create_irsa_false_role"
+  provider_url                  = "oidc.eks.us-west-2.amazonaws.com/id/dummy-oidc-provider"
+  oidc_fully_qualified_subjects = ["system:serviceaccount:logging:logging-loki"]
+  policy_arns                   = [aws_iam_policy.loki_policy.arn]
+}
+
+resource "aws_iam_policy" "loki_policy" {
+  name        = var.name_prefix
+  path        = "/"
+  description = "IAM policy for Loki to have necessary permissions to use S3 for storing logs."
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = ["arn:${data.aws_partition.current.partition}:s3:::${module.bucket.s3_bucket}"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:*Object"]
+        Resource = ["arn:${data.aws_partition.current.partition}:s3:::${module.bucket.s3_bucket}/*"]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Decrypt"
+        ]
+        Resource = [module.kms_key.key_arn]
+      }
+    ]
+  })
 }

--- a/examples/complete/providers.tf
+++ b/examples/complete/providers.tf
@@ -7,7 +7,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.region
-}

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -14,6 +14,12 @@ variable "create_irsa" {
   default     = true
 }
 
+variable "role_arn" {
+  type        = string
+  description = "ARN of the IAM role to be used in the S3 bucket policy"
+  default     = ""
+}
+
 variable "irsa_iam_role_name" {
   description = "IRSA role name."
   type        = string

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,9 +1,3 @@
-variable "region" {
-  description = "The AWS region to deploy into"
-  type        = string
-  default     = "us-east-2"
-}
-
 variable "name_prefix" {
   description = "Prefix to use when naming resources."
   type        = string

--- a/go.mod
+++ b/go.mod
@@ -40,12 +40,14 @@ require (
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/otp v1.2.0 // indirect
+	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/tmccombs/hcl2json v0.3.3 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
@@ -63,5 +65,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	google.golang.org/grpc v1.53.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,9 @@ github.com/klauspost/compress v1.15.11 h1:Lcadnb3RKGin4FYM/orgq0qde+nc15E5Cbqg4B
 github.com/klauspost/compress v1.15.11/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -419,6 +420,9 @@ github.com/pquerna/otp v1.2.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -975,8 +979,9 @@ google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ module "s3_bucket" {
   }
 }
 
-resource "aws_s3_bucket_policy" "bucket_policy" {
+resource "aws_s3_bucket_policy" "bucket_policy_irsa" {
   count  = var.create_irsa ? 1 : 0
   bucket = module.s3_bucket.s3_bucket_id
 
@@ -55,6 +55,32 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
         Effect = "Allow"
         Principal = {
           AWS = module.irsa[0].iam_role_arn
+        }
+        Resource = [
+          module.s3_bucket.s3_bucket_arn,
+          "${module.s3_bucket.s3_bucket_arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  count  = var.create_irsa ? 0 : 1
+  bucket = module.s3_bucket.s3_bucket_id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject",
+          "s3:PutObject"
+        ]
+        Effect = "Allow"
+        Principal = {
+          AWS = var.role_arn
         }
         Resource = [
           module.s3_bucket.s3_bucket_arn,

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "create_irsa" {
   default     = true
 }
 
+variable "role_arn" {
+  type        = string
+  description = "ARN of the IAM role to be used in the S3 bucket policy"
+  default     = ""
+}
+
 variable "irsa_iam_role_name" {
   type        = string
   description = "IAM role name for IRSA"


### PR DESCRIPTION
Closes https://github.com/defenseunicorns/terraform-aws-uds-s3/issues/18

Creating the S3 bucket policy should not depend on creating the IRSA resources via this S3 module. This PR adds a `aws_s3_bucket_policy` resource that can be created when `create_irsa` is set to false.

A test case has been added to verify that the S3 bucket policy gets created when `create_irsa` is set to `false`.