### PR TITLE
Restrict testing to US regions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This module is provide a bucket for the needs of UDS. While the original intent 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.9.0 |
 
 ## Modules
 
@@ -53,4 +53,3 @@ This module is provide a bucket for the needs of UDS. While the original intent 
 |------|-------------|
 | <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | S3 Bucket ARN |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | S3 Bucket Name |
-<!-- END_TF_DOCS -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,4 +1,4 @@
-Example of how to use this S3 module
+<!-- END_TF_DOCS -->Example of how to use this S3 module
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -28,6 +28,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create_bucket_lifecycle"></a> [create\_bucket\_lifecycle](#input\_create\_bucket\_lifecycle) | If true, create a bucket lifecycle | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy into | `string` | `"us-east-2"` | no |
 
 ## Outputs
 

--- a/examples/complete/providers.tf
+++ b/examples/complete/providers.tf
@@ -7,3 +7,7 @@ terraform {
     }
   }
 }
+
+provider "aws" {
+  region = var.region
+}

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -3,3 +3,9 @@ variable "create_bucket_lifecycle" {
   type        = bool
   default     = false
 }
+
+variable "region" {
+  description = "The AWS region to deploy into"
+  type        = string
+  default     = "us-east-2"
+}


### PR DESCRIPTION
This brings back the region variable for the example and will use a random, stable US region for Terratest.

Tested changes with `go test` in the `test` dir.